### PR TITLE
Add asteroid tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ public/
 # legacy
 build/
 dist/
+lib/
 
 # Dependency directories
 node_modules/

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "build": "webpack --mode production",
     "build-dev": "webpack --mode none",
     "start:dev": "webpack serve --mode production",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx || (exit 0)"
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx || (exit 0)",
+    "pretest": "tsc",
+    "test": "node --test"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.62.0",

--- a/test/asteroid.test.js
+++ b/test/asteroid.test.js
@@ -1,0 +1,106 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const assert = require('node:assert');
+const test = require('node:test');
+
+// Minimal Phaser stub for RNG
+global.Phaser = { Math: { RND: { between: (min, max) => min } } };
+
+class MockImage {
+        constructor() {
+                this.scale = 1;
+        }
+        setVelocity(x, y) {
+                this.velocity = { x, y };
+        }
+        setAngularVelocity(r) {
+                this.angularVelocity = r;
+        }
+        setScale(s) {
+                this.scale = s;
+        }
+}
+
+class MockPhysics {
+        constructor() {
+                this.world = {
+                        wrapCalls: [],
+                        wrap: (obj, padding) => {
+                                this.world.wrapCalls.push({ obj, padding });
+                        }
+                };
+                this.add = {
+                        image: () => new MockImage()
+                };
+        }
+}
+
+function createMockScene() {
+        return {
+                physics: new MockPhysics(),
+                cameras: { main: { x: 0, y: 0, width: 100, height: 100 } }
+        };
+}
+
+const Asteroid = require('../lib/Objects/Asteroid').default;
+
+test('createRandom creates asteroid if below threshold', () => {
+        const scene = createMockScene();
+        const asteroids = [];
+        Asteroid.createRandom(scene, asteroids);
+        assert.strictEqual(asteroids.length, 1);
+        assert.ok(asteroids[0].isBig);
+});
+
+test('createRandom respects big asteroid limit', () => {
+        const scene = createMockScene();
+        const asteroids = [];
+        for (let i = 0; i < Asteroid.minBigAsteroids; i++) {
+                asteroids.push(new Asteroid(scene, {
+                        posX: 0,
+                        posY: 0,
+                        velocityX: 0,
+                        velocityY: 0,
+                        rotation: 0,
+                        isBig: true
+                }));
+        }
+        Asteroid.createRandom(scene, asteroids);
+        assert.strictEqual(asteroids.length, Asteroid.minBigAsteroids);
+});
+
+test('wrap calls physics.world.wrap on each asteroid', () => {
+        const scene = createMockScene();
+        const asteroids = [
+                new Asteroid(scene, {
+                        posX: 0,
+                        posY: 0,
+                        velocityX: 0,
+                        velocityY: 0,
+                        rotation: 0,
+                        isBig: true
+                }),
+                new Asteroid(scene, {
+                        posX: 1,
+                        posY: 1,
+                        velocityX: 0,
+                        velocityY: 0,
+                        rotation: 0,
+                        isBig: false
+                })
+        ];
+        Asteroid.wrap(scene.physics, asteroids);
+        assert.strictEqual(scene.physics.world.wrapCalls.length, 2);
+});
+
+test('constructor scales small asteroids', () => {
+        const scene = createMockScene();
+        const asteroid = new Asteroid(scene, {
+                posX: 0,
+                posY: 0,
+                velocityX: 0,
+                velocityY: 0,
+                rotation: 0,
+                isBig: false
+        });
+        assert.strictEqual(asteroid.asteroid.scale, Asteroid.smallAsteroidScale);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,11 @@
 {
 	"compilerOptions": {
 		"target": "es2017",
-		"module": "commonjs",
-		"esModuleInterop": true,
-		"rootDir": "./src/ts/",
-		"sourceMap": true,
-		"moduleResolution": "node"
-	}
+        "module": "commonjs",
+        "esModuleInterop": true,
+        "rootDir": "./src/ts/",
+        "outDir": "./lib",
+        "sourceMap": true,
+        "moduleResolution": "node"
+        }
 }


### PR DESCRIPTION
## Summary
- create functional tests for the Asteroid class
- compile TypeScript before running tests
- ignore compiled output
- enable outDir in tsconfig

Lint and build were executed.

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848baf3d7ac8322b40feb26517cbda3