### PR TITLE
Fix asteroid typos

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "asteroids",
   "version": "0.0.1",
-  "description": "Game with spacecraft destroying asterids.",
+  "description": "Game with spacecraft destroying asteroids.",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com:frast/asteroids.git"

--- a/src/ts/Game.ts
+++ b/src/ts/Game.ts
@@ -12,7 +12,7 @@ const gameConfig: Phaser.Types.Core.GameConfig = {
 	height: 900,
 	type: Phaser.AUTO,
 	parent: "content",
-	title: "Game with spacecraft destroying asterids",
+	title: "Game with spacecraft destroying asteroids",
 	physics: {
 		default: "arcade",
 		arcade: {

--- a/src/ts/Scenes/SplashScreen.ts
+++ b/src/ts/Scenes/SplashScreen.ts
@@ -18,7 +18,7 @@ export default class SplashScreen extends Phaser.Scene {
 			.text(
 				this.cameras.main.centerX,
 				this.cameras.main.centerY * 0.5,
-				"Game with spacecraft destroying asterids"
+				"Game with spacecraft destroying asteroids"
 			)
 			.setOrigin(0.5, 0)
 			.setFontFamily("monospace")


### PR DESCRIPTION
## Summary
- fix 'asterids' typos in Game.ts and SplashScreen.ts
- update description in package.json
- ran `npm run lint` and `npm run build`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853fed982b48322aa38bf0b5447332a