### PR TITLE
Import Phaser explicitly

### DIFF
--- a/src/ts/Game.ts
+++ b/src/ts/Game.ts
@@ -1,4 +1,4 @@
-import 'phaser';
+import Phaser from 'phaser';
 import Boot from "./Scenes/Boot";
 import Preloader from "./Scenes/Preloader";
 import MainMenu from "./Scenes/MainMenu";

--- a/src/ts/Objects/Asteroid.ts
+++ b/src/ts/Objects/Asteroid.ts
@@ -1,3 +1,5 @@
+import Phaser from 'phaser';
+
 type InitialAsteroidState = {
 	readonly posX: number;
 	readonly posY: number;

--- a/src/ts/Scenes/Boot.ts
+++ b/src/ts/Scenes/Boot.ts
@@ -1,3 +1,4 @@
+import Phaser from 'phaser';
 import Preloader from "./Preloader";
 import Utilities from "../Utilities";
 

--- a/src/ts/Scenes/MainGame.ts
+++ b/src/ts/Scenes/MainGame.ts
@@ -1,3 +1,4 @@
+import Phaser from 'phaser';
 import Asteroid from "../Objects/Asteroid";
 import Utilities from "../Utilities";
 

--- a/src/ts/Scenes/MainMenu.ts
+++ b/src/ts/Scenes/MainMenu.ts
@@ -1,3 +1,4 @@
+import Phaser from 'phaser';
 import Utilities from "../Utilities";
 import MainGame from "./MainGame";
 import MainSettings from "./MainSettings";

--- a/src/ts/Scenes/MainSettings.ts
+++ b/src/ts/Scenes/MainSettings.ts
@@ -1,3 +1,4 @@
+import Phaser from 'phaser';
 import Utilities from "../Utilities";
 import MainMenu from "./MainMenu";
 

--- a/src/ts/Scenes/Preloader.ts
+++ b/src/ts/Scenes/Preloader.ts
@@ -1,3 +1,4 @@
+import Phaser from 'phaser';
 import SplashScreen from "./SplashScreen";
 import Utilities from "../Utilities";
 

--- a/src/ts/Scenes/SplashScreen.ts
+++ b/src/ts/Scenes/SplashScreen.ts
@@ -1,3 +1,4 @@
+import Phaser from 'phaser';
 import Utilities from "../Utilities";
 import MainMenu from "./MainMenu";
 


### PR DESCRIPTION
## Summary
- import Phaser from the package instead of relying on the global
- add Phaser import in all TypeScript files that use Phaser types

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853ff5c322c832292ecbe80d71122c8